### PR TITLE
Improve landmark selection UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# a11y-extension
+# A11y Lab Chrome Extension
+
+A Chrome extension that lets developers experiment with accessibility landmarks, custom shortcuts, and jump menus on any page. Use the edit mode to visually pick regions of the page and turn them into landmarks, then switch to preview mode to interact with the experience.
+
+## Features
+
+- **Visual landmark selection** – Start a selection from the popup, hover the page to highlight regions, and click to assign a name, role, and optional shortcut.
+- **Landmark management** – Review, focus, or remove previously defined landmarks directly from the popup.
+- **Preview mode** – Apply ARIA landmarks to the page, jump through regions with your shortcuts (Alt+key combinations), and navigate with a floating jump menu.
+- **Jump menu** – Toggle a floating navigation menu that lists all defined landmarks for quick navigation.
+
+## Getting started
+
+1. Open `chrome://extensions` in Chrome.
+2. Enable **Developer mode** in the top-right corner.
+3. Choose **Load unpacked** and select the `a11y-extension` directory.
+4. Navigate to any page, open the extension popup, and start configuring landmarks.
+
+### Workflow
+
+1. In the popup choose **Edit mode** and click **Select area** after filling the landmark details.
+2. On the page, hover to highlight sections. Click the desired element to apply the configuration.
+3. Switch to **Preview mode** to try keyboard shortcuts and use the jump menu.
+4. Use the **Configured landmarks** list to focus on a region or remove it.
+
+Settings are stored per page (origin + path) so you can create different experiments for each route.

--- a/content/contentScript.js
+++ b/content/contentScript.js
@@ -1,0 +1,506 @@
+const pageState = {
+  mode: 'preview',
+  selecting: false,
+  pendingElement: null,
+  currentSelectionConfig: null,
+  hoveredElement: null,
+  overlay: null,
+  selectionActions: null,
+  landmarks: [],
+  jumpMenuEnabled: false,
+  shortcutHandler: null,
+  pageKey: `${location.origin}${location.pathname}`
+};
+
+const STORAGE_KEY = 'a11yLab';
+
+init();
+
+async function init() {
+  await loadStateFromStorage();
+  applyLandmarks();
+  ensureShortcutHandler();
+  if (pageState.jumpMenuEnabled) {
+    renderJumpMenu();
+  }
+}
+
+function ensureShortcutHandler() {
+  if (pageState.shortcutHandler) return;
+  pageState.shortcutHandler = handleShortcut.bind(null);
+  document.addEventListener('keydown', pageState.shortcutHandler, true);
+}
+
+async function loadStateFromStorage() {
+  const stored = await chrome.storage.local.get([STORAGE_KEY]);
+  const root = stored[STORAGE_KEY] || { pages: {} };
+  const page = root.pages?.[pageState.pageKey] || {};
+  pageState.landmarks = page.landmarks || [];
+  pageState.jumpMenuEnabled = Boolean(page.jumpMenuEnabled);
+}
+
+async function saveStateToStorage() {
+  const stored = await chrome.storage.local.get([STORAGE_KEY]);
+  const root = stored[STORAGE_KEY] || { pages: {} };
+  root.pages = root.pages || {};
+  root.pages[pageState.pageKey] = {
+    landmarks: pageState.landmarks,
+    jumpMenuEnabled: pageState.jumpMenuEnabled
+  };
+  await chrome.storage.local.set({ [STORAGE_KEY]: root });
+}
+
+function applyLandmarks() {
+  clearExistingLandmarks();
+  for (const landmark of pageState.landmarks) {
+    const element = document.querySelector(landmark.selector);
+    if (!element) continue;
+
+    if (!Object.prototype.hasOwnProperty.call(element.dataset, 'a11yLabOriginalRole')) {
+      element.dataset.a11yLabOriginalRole = element.getAttribute('role') ?? '';
+    }
+    if (!Object.prototype.hasOwnProperty.call(element.dataset, 'a11yLabOriginalLabel')) {
+      element.dataset.a11yLabOriginalLabel = element.getAttribute('aria-label') ?? '';
+    }
+
+    element.setAttribute('role', landmark.role);
+    element.setAttribute('aria-label', landmark.label);
+
+    if (!element.hasAttribute('tabindex')) {
+      element.setAttribute('tabindex', '-1');
+      element.dataset.a11yLabTabIndex = 'true';
+    }
+    element.dataset.a11yLabLandmarkId = landmark.id;
+  }
+  if (pageState.jumpMenuEnabled) {
+    renderJumpMenu();
+  } else {
+    removeJumpMenu();
+  }
+}
+
+function clearExistingLandmarks() {
+  const candidates = document.querySelectorAll('[data-a11y-lab-landmark-id]');
+  candidates.forEach((element) => {
+    const originalRole = element.dataset.a11yLabOriginalRole;
+    const originalLabel = element.dataset.a11yLabOriginalLabel;
+
+    if (typeof originalRole === 'string') {
+      if (originalRole === '') {
+        element.removeAttribute('role');
+      } else {
+        element.setAttribute('role', originalRole);
+      }
+      delete element.dataset.a11yLabOriginalRole;
+    }
+
+    if (typeof originalLabel === 'string') {
+      if (originalLabel === '') {
+        element.removeAttribute('aria-label');
+      } else {
+        element.setAttribute('aria-label', originalLabel);
+      }
+      delete element.dataset.a11yLabOriginalLabel;
+    }
+
+    if (element.dataset.a11yLabTabIndex === 'true') {
+      element.removeAttribute('tabindex');
+      delete element.dataset.a11yLabTabIndex;
+    }
+    delete element.dataset.a11yLabLandmarkId;
+  });
+}
+
+function handleShortcut(event) {
+  if (pageState.mode !== 'preview') return;
+  const pressed = serializeShortcut(event);
+  if (!pressed) return;
+  const match = pageState.landmarks.find((landmark) => landmark.shortcut && normalizeShortcut(landmark.shortcut) === pressed);
+  if (!match) return;
+  const element = document.querySelector(match.selector);
+  if (!element) return;
+  event.preventDefault();
+  focusElement(element);
+}
+
+function serializeShortcut(event) {
+  const keys = [];
+  if (event.altKey) keys.push('alt');
+  if (event.ctrlKey) keys.push('ctrl');
+  if (event.metaKey) keys.push('meta');
+  if (event.shiftKey) keys.push('shift');
+  const key = event.key.toLowerCase();
+  if (key === 'alt' || key === 'control' || key === 'shift' || key === 'meta') return null;
+  keys.push(key);
+  return keys.join('+');
+}
+
+function normalizeShortcut(shortcut) {
+  return shortcut
+    .split('+')
+    .map((part) => part.trim().toLowerCase())
+    .filter(Boolean)
+    .join('+');
+}
+
+function startSelection(config) {
+  if (pageState.selecting) return;
+  pageState.mode = 'edit';
+  pageState.selecting = true;
+  pageState.pendingElement = null;
+  pageState.currentSelectionConfig = config;
+  document.addEventListener('pointermove', handlePointerMove, true);
+  document.addEventListener('pointerdown', handlePointerDown, true);
+  document.addEventListener('keydown', cancelSelectionOnEscape, true);
+  window.addEventListener('scroll', refreshOverlay, true);
+  window.addEventListener('resize', refreshOverlay, true);
+  document.documentElement.classList.add('a11y-lab-selecting');
+  ensureOverlay();
+  removeSelectionActions();
+  showSelectionNotice();
+}
+
+function showSelectionNotice() {
+  const noticeId = 'a11y-lab-selection-notice';
+  if (document.getElementById(noticeId)) return;
+  const notice = document.createElement('div');
+  notice.id = noticeId;
+  notice.textContent = 'Click the element to preview and choose Save. Press Esc to cancel.';
+  notice.setAttribute('role', 'status');
+  notice.setAttribute('aria-live', 'polite');
+  notice.className = 'a11y-lab-selection-notice';
+  document.body.appendChild(notice);
+}
+
+function hideSelectionNotice() {
+  const notice = document.getElementById('a11y-lab-selection-notice');
+  if (notice) {
+    notice.remove();
+  }
+}
+
+function handlePointerMove(event) {
+  if (!pageState.selecting) return;
+  const target = getSelectableTarget(event);
+  if (!target) return;
+  highlightElement(target);
+}
+
+function handlePointerDown(event) {
+  if (!pageState.selecting) return;
+  if (pageState.selectionActions?.contains(event.target)) {
+    return;
+  }
+  event.preventDefault();
+  event.stopPropagation();
+  const target = getSelectableTarget(event);
+  if (!target) return;
+  pageState.pendingElement = target;
+  highlightElement(target);
+  showSelectionActions();
+}
+
+function cancelSelectionOnEscape(event) {
+  if (event.key === 'Escape') {
+    event.preventDefault();
+    stopSelection();
+  }
+}
+
+async function commitSelection() {
+  const element = pageState.pendingElement;
+  if (!element) return;
+  const selector = getUniqueSelector(element);
+  const { label, role, shortcut } = pageState.currentSelectionConfig;
+  const landmark = {
+    id: crypto.randomUUID(),
+    selector,
+    label,
+    role,
+    shortcut: shortcut || ''
+  };
+  pageState.landmarks = [...pageState.landmarks.filter((item) => item.selector !== selector), landmark];
+  await saveStateToStorage();
+  stopSelection();
+  applyLandmarks();
+}
+
+function stopSelection() {
+  pageState.selecting = false;
+  pageState.pendingElement = null;
+  pageState.currentSelectionConfig = null;
+  document.removeEventListener('pointermove', handlePointerMove, true);
+  document.removeEventListener('pointerdown', handlePointerDown, true);
+  document.removeEventListener('keydown', cancelSelectionOnEscape, true);
+  window.removeEventListener('scroll', refreshOverlay, true);
+  window.removeEventListener('resize', refreshOverlay, true);
+  document.documentElement.classList.remove('a11y-lab-selecting');
+  hideSelectionNotice();
+  removeOverlay();
+  removeSelectionActions();
+}
+
+function highlightElement(element) {
+  pageState.hoveredElement = element;
+  ensureOverlay();
+  updateOverlayPosition();
+}
+
+function ensureOverlay() {
+  if (pageState.overlay) return;
+  const overlay = document.createElement('div');
+  overlay.id = 'a11y-lab-overlay';
+  overlay.className = 'a11y-lab-overlay';
+  document.body.appendChild(overlay);
+  pageState.overlay = overlay;
+}
+
+function removeOverlay() {
+  if (!pageState.overlay) return;
+  pageState.overlay.remove();
+  pageState.overlay = null;
+}
+
+function refreshOverlay() {
+  if (!pageState.hoveredElement) return;
+  updateOverlayPosition();
+}
+
+function updateOverlayPosition() {
+  if (!pageState.overlay || !pageState.hoveredElement) return;
+  const rect = pageState.hoveredElement.getBoundingClientRect();
+  pageState.overlay.style.display = 'block';
+  pageState.overlay.style.top = `${window.scrollY + rect.top}px`;
+  pageState.overlay.style.left = `${window.scrollX + rect.left}px`;
+  pageState.overlay.style.width = `${rect.width}px`;
+  pageState.overlay.style.height = `${rect.height}px`;
+  positionSelectionActions(rect);
+}
+
+function getUniqueSelector(element) {
+  if (element === document.body) {
+    return 'body';
+  }
+  if (element === document.documentElement) {
+    return 'html';
+  }
+  if (element.id) {
+    return `#${CSS.escape(element.id)}`;
+  }
+  const path = [];
+  let current = element;
+  while (current && current.nodeType === Node.ELEMENT_NODE && current !== document.body) {
+    let selector = current.nodeName.toLowerCase();
+    if (current.className) {
+      const className = Array.from(current.classList)
+        .slice(0, 3)
+        .map((cls) => `.${CSS.escape(cls)}`)
+        .join('');
+      selector += className;
+    }
+    const siblings = Array.from(current.parentNode?.children || []);
+    const index = siblings.indexOf(current) + 1;
+    selector += `:nth-child(${index})`;
+    path.unshift(selector);
+    current = current.parentElement;
+  }
+  return path.join(' > ');
+}
+
+function focusElement(element) {
+  const previouslyTabbable = element.hasAttribute('tabindex');
+  if (!previouslyTabbable) {
+    element.setAttribute('tabindex', '-1');
+  }
+  element.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  element.focus({ preventScroll: true });
+  if (!previouslyTabbable) {
+    element.addEventListener('blur', () => {
+      element.removeAttribute('tabindex');
+    }, { once: true });
+  }
+}
+
+function renderJumpMenu() {
+  removeJumpMenu();
+  if (!pageState.jumpMenuEnabled || !pageState.landmarks.length) return;
+  const menu = document.createElement('nav');
+  menu.id = 'a11y-lab-jump-menu';
+  menu.className = 'a11y-lab-jump-menu';
+  menu.setAttribute('aria-label', 'Landmark navigation');
+
+  const title = document.createElement('div');
+  title.className = 'a11y-lab-jump-menu__title';
+  title.textContent = 'Landmarks';
+
+  const list = document.createElement('ul');
+  list.className = 'a11y-lab-jump-menu__list';
+
+  for (const landmark of pageState.landmarks) {
+    const item = document.createElement('li');
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.textContent = landmark.label;
+    button.addEventListener('click', () => {
+      const element = document.querySelector(landmark.selector);
+      if (element) {
+        focusElement(element);
+      }
+    });
+    item.appendChild(button);
+    list.appendChild(item);
+  }
+
+  menu.append(title, list);
+  document.body.appendChild(menu);
+}
+
+function removeJumpMenu() {
+  const menu = document.getElementById('a11y-lab-jump-menu');
+  if (menu) {
+    menu.remove();
+  }
+}
+
+async function handleRemoveLandmark(id) {
+  pageState.landmarks = pageState.landmarks.filter((landmark) => landmark.id !== id);
+  await saveStateToStorage();
+  applyLandmarks();
+}
+
+function handleFocusLandmark(id) {
+  const landmark = pageState.landmarks.find((item) => item.id === id);
+  if (!landmark) return;
+  const element = document.querySelector(landmark.selector);
+  if (!element) return;
+  focusElement(element);
+}
+
+function getSelectableTarget(event) {
+  const path = event.composedPath();
+  for (const candidate of path) {
+    if (!(candidate instanceof Element)) continue;
+    if (candidate.id === 'a11y-lab-overlay') continue;
+    if (candidate.closest && candidate.closest('#a11y-lab-selection-actions')) continue;
+    if (candidate === document.documentElement || candidate === document.body) continue;
+    return candidate;
+  }
+  return null;
+}
+
+function ensureSelectionActions() {
+  if (pageState.selectionActions) return pageState.selectionActions;
+  const actions = document.createElement('div');
+  actions.id = 'a11y-lab-selection-actions';
+  actions.className = 'a11y-lab-selection-actions';
+
+  const saveButton = document.createElement('button');
+  saveButton.type = 'button';
+  saveButton.className = 'a11y-lab-selection-actions__save';
+  saveButton.textContent = 'Save landmark';
+  saveButton.addEventListener('click', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    void commitSelection();
+  });
+
+  const cancelButton = document.createElement('button');
+  cancelButton.type = 'button';
+  cancelButton.className = 'a11y-lab-selection-actions__cancel';
+  cancelButton.textContent = 'Cancel';
+  cancelButton.addEventListener('click', (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    stopSelection();
+  });
+
+  actions.append(saveButton, cancelButton);
+  document.body.appendChild(actions);
+  pageState.selectionActions = actions;
+  return actions;
+}
+
+function showSelectionActions() {
+  const actions = ensureSelectionActions();
+  actions.style.display = 'flex';
+  const rect = pageState.hoveredElement?.getBoundingClientRect();
+  if (rect) {
+    positionSelectionActions(rect);
+  }
+}
+
+function positionSelectionActions(targetRect) {
+  if (!pageState.selectionActions || pageState.selectionActions.style.display === 'none') return;
+  const actions = pageState.selectionActions;
+  const viewportHeight = window.innerHeight;
+  const actionsHeight = actions.offsetHeight || actions.getBoundingClientRect().height || 0;
+  const topBelow = window.scrollY + targetRect.bottom + 12;
+  const topAbove = window.scrollY + targetRect.top - actionsHeight - 12;
+  const preferredTop = targetRect.bottom + 12 < viewportHeight ? topBelow : Math.max(window.scrollY, topAbove);
+  const actionsWidth = actions.offsetWidth || actions.getBoundingClientRect().width || 0;
+  const maxLeft = window.scrollX + window.innerWidth - actionsWidth - 12;
+  const minLeft = window.scrollX + 12;
+  const desiredLeft = window.scrollX + targetRect.left;
+  const clampedLeft = Math.min(Math.max(desiredLeft, minLeft), Math.max(minLeft, maxLeft));
+  actions.style.top = `${preferredTop}px`;
+  actions.style.left = `${clampedLeft}px`;
+}
+
+function removeSelectionActions() {
+  if (!pageState.selectionActions) return;
+  pageState.selectionActions.remove();
+  pageState.selectionActions = null;
+}
+
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  switch (message.type) {
+    case 'get-state': {
+      sendResponse({
+        mode: pageState.mode,
+        jumpMenuEnabled: pageState.jumpMenuEnabled,
+        landmarks: pageState.landmarks
+      });
+      break;
+    }
+    case 'set-mode': {
+      pageState.mode = message.mode === 'edit' ? 'edit' : 'preview';
+      if (pageState.mode === 'preview') {
+        applyLandmarks();
+      } else {
+        removeJumpMenu();
+      }
+      sendResponse({ mode: pageState.mode });
+      break;
+    }
+    case 'start-selection': {
+      startSelection(message.payload);
+      sendResponse({ selecting: true });
+      break;
+    }
+    case 'remove-landmark': {
+      handleRemoveLandmark(message.id).then(() => {
+        sendResponse({ landmarks: pageState.landmarks });
+      });
+      return true;
+    }
+    case 'focus-landmark': {
+      handleFocusLandmark(message.id);
+      sendResponse({});
+      break;
+    }
+    case 'toggle-jump-menu': {
+      pageState.jumpMenuEnabled = !pageState.jumpMenuEnabled;
+      if (pageState.jumpMenuEnabled) {
+        renderJumpMenu();
+      } else {
+        removeJumpMenu();
+      }
+      saveStateToStorage().then(() => {
+        sendResponse({ jumpMenuEnabled: pageState.jumpMenuEnabled });
+      });
+      return true;
+    }
+    default:
+      break;
+  }
+});

--- a/content/contentStyles.css
+++ b/content/contentStyles.css
@@ -1,0 +1,119 @@
+#a11y-lab-overlay {
+  position: absolute;
+  border: 2px solid #3b82f6;
+  background: rgba(59, 130, 246, 0.15);
+  pointer-events: none;
+  z-index: 2147483647;
+  display: none;
+}
+
+html.a11y-lab-selecting,
+html.a11y-lab-selecting body {
+  cursor: crosshair !important;
+}
+
+.a11y-lab-selection-notice {
+  position: fixed;
+  top: 1rem;
+  right: 1rem;
+  padding: 0.75rem 1rem;
+  background: #1d4ed8;
+  color: #fff;
+  border-radius: 0.5rem;
+  box-shadow: 0 10px 25px rgba(15, 23, 42, 0.25);
+  z-index: 2147483647;
+  font-family: system-ui, sans-serif;
+  font-size: 0.9rem;
+}
+
+#a11y-lab-selection-actions {
+  position: absolute;
+  display: none;
+  gap: 0.5rem;
+  padding: 0.5rem;
+  border-radius: 0.5rem;
+  background: rgba(15, 23, 42, 0.95);
+  box-shadow: 0 10px 30px rgba(15, 23, 42, 0.35);
+  z-index: 2147483647;
+  font-family: system-ui, sans-serif;
+}
+
+.a11y-lab-selection-actions button {
+  border: none;
+  border-radius: 0.375rem;
+  padding: 0.35rem 0.75rem;
+  font: inherit;
+  cursor: pointer;
+  color: #fff;
+}
+
+.a11y-lab-selection-actions__save {
+  background: #22c55e;
+}
+
+.a11y-lab-selection-actions__save:hover,
+.a11y-lab-selection-actions__save:focus {
+  background: #16a34a;
+  outline: 2px solid #bbf7d0;
+  outline-offset: 2px;
+}
+
+.a11y-lab-selection-actions__cancel {
+  background: #ef4444;
+}
+
+.a11y-lab-selection-actions__cancel:hover,
+.a11y-lab-selection-actions__cancel:focus {
+  background: #dc2626;
+  outline: 2px solid #fecaca;
+  outline-offset: 2px;
+}
+
+#a11y-lab-jump-menu {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  background: rgba(15, 23, 42, 0.95);
+  color: #fff;
+  padding: 1rem;
+  border-radius: 0.75rem;
+  width: 240px;
+  max-height: 60vh;
+  overflow: auto;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.3);
+  z-index: 2147483647;
+  font-family: system-ui, sans-serif;
+}
+
+.a11y-lab-jump-menu__title {
+  font-weight: 700;
+  margin-bottom: 0.5rem;
+  font-size: 1rem;
+}
+
+.a11y-lab-jump-menu__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.a11y-lab-jump-menu__list button {
+  width: 100%;
+  padding: 0.5rem;
+  border-radius: 0.5rem;
+  background: #2563eb;
+  border: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.a11y-lab-jump-menu__list button:hover,
+.a11y-lab-jump-menu__list button:focus {
+  background: #1d4ed8;
+  outline: 2px solid #93c5fd;
+  outline-offset: 2px;
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,19 @@
+{
+  "manifest_version": 3,
+  "name": "A11y Lab",
+  "version": "1.0.0",
+  "description": "Experiment with accessibility landmarks, shortcuts, and jump menus on any page.",
+  "permissions": ["storage", "activeTab", "scripting"],
+  "action": {
+    "default_popup": "popup/popup.html",
+    "default_title": "A11y Lab"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content/contentScript.js"],
+      "css": ["content/contentStyles.css"],
+      "run_at": "document_idle"
+    }
+  ]
+}

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -1,0 +1,94 @@
+:root {
+  font-family: system-ui, sans-serif;
+  color-scheme: light dark;
+}
+
+body {
+  margin: 0;
+  padding: 1rem;
+  width: 320px;
+  background: #f8f9fb;
+  color: #202124;
+}
+
+h1 {
+  font-size: 1.25rem;
+  margin: 0 0 0.5rem;
+}
+
+section {
+  margin-bottom: 1rem;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.875rem;
+  margin-bottom: 0.5rem;
+}
+
+input,
+select,
+button {
+  font: inherit;
+  padding: 0.4rem 0.6rem;
+  border-radius: 0.4rem;
+  border: 1px solid #cbd5e1;
+}
+
+button {
+  cursor: pointer;
+  background: #3b82f6;
+  color: #fff;
+  border: none;
+  font-weight: 600;
+  transition: background 0.2s ease;
+}
+
+button[aria-pressed="true"],
+button:hover {
+  background: #1d4ed8;
+}
+
+.toggle-group {
+  display: flex;
+  gap: 0.5rem;
+}
+
+#landmark-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.landmark-item {
+  background: #fff;
+  border-radius: 0.5rem;
+  border: 1px solid #cbd5e1;
+  padding: 0.5rem;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.landmark-meta {
+  font-size: 0.75rem;
+  color: #475569;
+}
+
+.landmark-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+
+.landmark-actions button {
+  background: #ef4444;
+}
+
+.landmark-actions button.secondary {
+  background: #6366f1;
+}

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>A11y Lab</title>
+  <link rel="stylesheet" href="popup.css" />
+</head>
+<body>
+  <main>
+    <h1>A11y Lab</h1>
+    <section>
+      <h2>Mode</h2>
+      <div class="toggle-group">
+        <button id="mode-edit" aria-pressed="false">Edit mode</button>
+        <button id="mode-preview" aria-pressed="false">Preview mode</button>
+      </div>
+    </section>
+    <section>
+      <h2>Create landmark</h2>
+      <label>
+        Name
+        <input id="landmark-label" type="text" placeholder="e.g. Main content" />
+      </label>
+      <label>
+        Landmark type
+        <select id="landmark-role">
+          <option value="main">Main</option>
+          <option value="banner">Banner</option>
+          <option value="navigation">Navigation</option>
+          <option value="complementary">Complementary</option>
+          <option value="contentinfo">Content info</option>
+          <option value="region">Region</option>
+        </select>
+      </label>
+      <label>
+        Shortcut (Alt+Key)
+        <input id="landmark-shortcut" type="text" placeholder="Alt+1" />
+      </label>
+      <button id="start-selection">Select area</button>
+    </section>
+    <section>
+      <h2>Configured landmarks</h2>
+      <ul id="landmark-list" aria-live="polite"></ul>
+    </section>
+    <section>
+      <h2>Jump menu</h2>
+      <button id="toggle-jump-menu">Toggle jump menu</button>
+    </section>
+  </main>
+  <script src="popup.js" type="module"></script>
+</body>
+</html>

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -1,0 +1,159 @@
+const state = {
+  tabId: null,
+  pageKey: null,
+  mode: 'preview',
+  jumpMenuEnabled: false,
+  landmarks: []
+};
+
+const modeEditButton = document.getElementById('mode-edit');
+const modePreviewButton = document.getElementById('mode-preview');
+const startSelectionButton = document.getElementById('start-selection');
+const toggleJumpMenuButton = document.getElementById('toggle-jump-menu');
+const landmarkList = document.getElementById('landmark-list');
+
+async function getActiveTab() {
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  return tab;
+}
+
+function getPageKey(urlString) {
+  try {
+    const url = new URL(urlString);
+    return `${url.origin}${url.pathname}`;
+  } catch (error) {
+    return 'global';
+  }
+}
+
+function renderLandmarks() {
+  landmarkList.innerHTML = '';
+  if (!state.landmarks.length) {
+    const empty = document.createElement('li');
+    empty.textContent = 'No landmarks yet.';
+    landmarkList.appendChild(empty);
+    return;
+  }
+
+  for (const landmark of state.landmarks) {
+    const item = document.createElement('li');
+    item.className = 'landmark-item';
+    item.innerHTML = `
+      <strong>${landmark.label}</strong>
+      <span class="landmark-meta">Role: ${landmark.role}</span>
+      ${landmark.shortcut ? `<span class="landmark-meta">Shortcut: ${landmark.shortcut}</span>` : ''}
+    `;
+
+    const actions = document.createElement('div');
+    actions.className = 'landmark-actions';
+
+    const focusButton = document.createElement('button');
+    focusButton.textContent = 'Focus';
+    focusButton.classList.add('secondary');
+    focusButton.addEventListener('click', () => focusLandmark(landmark.id));
+
+    const removeButton = document.createElement('button');
+    removeButton.textContent = 'Remove';
+    removeButton.addEventListener('click', () => removeLandmark(landmark.id));
+
+    actions.append(focusButton, removeButton);
+    item.append(actions);
+    landmarkList.appendChild(item);
+  }
+}
+
+async function syncStateFromContent() {
+  if (!state.tabId) return;
+  const response = await chrome.tabs.sendMessage(state.tabId, { type: 'get-state' }).catch(() => null);
+  if (!response) return;
+  state.mode = response.mode;
+  state.jumpMenuEnabled = response.jumpMenuEnabled;
+  state.landmarks = response.landmarks ?? [];
+  updateModeButtons();
+  updateJumpMenuButton();
+  renderLandmarks();
+}
+
+function updateModeButtons() {
+  modeEditButton.setAttribute('aria-pressed', state.mode === 'edit');
+  modePreviewButton.setAttribute('aria-pressed', state.mode === 'preview');
+}
+
+function updateJumpMenuButton() {
+  toggleJumpMenuButton.textContent = state.jumpMenuEnabled ? 'Hide jump menu' : 'Show jump menu';
+}
+
+async function setMode(mode) {
+  if (!state.tabId) return;
+  const response = await chrome.tabs
+    .sendMessage(state.tabId, { type: 'set-mode', mode })
+    .catch(() => null);
+  state.mode = response?.mode ?? mode;
+  updateModeButtons();
+}
+
+async function focusLandmark(id) {
+  if (!state.tabId) return;
+  await chrome.tabs.sendMessage(state.tabId, { type: 'focus-landmark', id }).catch(() => {});
+}
+
+async function removeLandmark(id) {
+  if (!state.tabId) return;
+  await chrome.tabs.sendMessage(state.tabId, { type: 'remove-landmark', id }).catch(() => {});
+  await syncStateFromContent();
+}
+
+async function startSelection() {
+  if (!state.tabId) return;
+  const label = document.getElementById('landmark-label').value.trim();
+  const role = document.getElementById('landmark-role').value;
+  const shortcut = document.getElementById('landmark-shortcut').value.trim();
+
+  if (!label) {
+    alert('Please provide a name for the landmark.');
+    return;
+  }
+
+  await setMode('edit');
+  await chrome.tabs.sendMessage(state.tabId, {
+    type: 'start-selection',
+    payload: { label, role, shortcut }
+  }).catch(() => {});
+}
+
+async function toggleJumpMenu() {
+  if (!state.tabId) return;
+  const response = await chrome.tabs.sendMessage(state.tabId, { type: 'toggle-jump-menu' }).catch(() => null);
+  if (response) {
+    state.jumpMenuEnabled = response.jumpMenuEnabled;
+    updateJumpMenuButton();
+  }
+}
+
+function registerStorageListener() {
+  chrome.storage.onChanged.addListener((changes, area) => {
+    if (area !== 'local') return;
+    if (!changes.a11yLab) return;
+    if (!state.pageKey) return;
+    const next = changes.a11yLab.newValue;
+    const prev = changes.a11yLab.oldValue;
+    const hasUpdate = Boolean(next?.pages?.[state.pageKey] || prev?.pages?.[state.pageKey]);
+    if (!hasUpdate) return;
+    syncStateFromContent();
+  });
+}
+
+async function init() {
+  registerStorageListener();
+  const tab = await getActiveTab();
+  state.tabId = tab?.id ?? null;
+  state.pageKey = getPageKey(tab?.url ?? '');
+  await syncStateFromContent();
+
+  modeEditButton.addEventListener('click', () => setMode('edit'));
+  modePreviewButton.addEventListener('click', () => setMode('preview'));
+  startSelectionButton.addEventListener('click', startSelection);
+  toggleJumpMenuButton.addEventListener('click', toggleJumpMenu);
+}
+
+init();


### PR DESCRIPTION
## Summary
- refine the in-page selection logic to ignore helper UI, track the pending element, and confirm with a save action
- add floating save and cancel controls that appear near the highlighted region while editing
- style the new selection controls to match the overlay experience

## Testing
- not run (Chrome extension manual validation)


------
https://chatgpt.com/codex/tasks/task_e_68d4d940ca1083308070497d6a50fe8f